### PR TITLE
Filter roles

### DIFF
--- a/lib/RT/Extension/Assets/Import/CSV.pm
+++ b/lib/RT/Extension/Assets/Import/CSV.pm
@@ -405,9 +405,9 @@ sub process_roles_field {
             # Is it safe to assume the Nobody account always starts with
             # Nobody?
             if ($name =~ /^Nobody/) {
-                $user = RT->Nobody;
+                $principal = RT->Nobody;
             } else {
-                $user->Load( $name );
+                $principal->Load( $name );
             }
         }
 

--- a/lib/RT/Extension/Assets/Import/CSV.pm
+++ b/lib/RT/Extension/Assets/Import/CSV.pm
@@ -388,7 +388,7 @@ sub process_roles_field {
         my $type      = 'user';
         my $principal = $user;
 
-        if ($name =~ /^Group: (.*)$/) {
+        if ($name =~ /^[Gg]roup: ?(.*)$/) {
             # Add a group.
             #
             # Lazy create a group for lookups.
@@ -570,7 +570,7 @@ asset ids.  Otherwise, asset id conflicts may occur.
 You can add multiple principals to role which support that (HeldBy & Contact)
 by separating them with ", ". The space is required as commas are allowed in
 usernames within RT. If you have a username with ", " in it, then sorry, you
-can add to assets with this tool. To add a group use "Group: Group name"
+can add to assets with this tool. To add a group use "group: Group name"
 
 Any users or groups in a role which aren't mentioned in the CSV will be
 removed from the asset.

--- a/lib/RT/Extension/Assets/Import/CSV.pm
+++ b/lib/RT/Extension/Assets/Import/CSV.pm
@@ -166,14 +166,37 @@ sub run {
                     }
                 } elsif ($asset->HasRole($field)) {
                     my $user = RT::User->new( $args{CurrentUser} );
-                    $user->Load( $value );
-                    $user = RT->Nobody unless $user->id;
-                    next if $asset->RoleGroup($field)->HasMember( $user->PrincipalId );
+                    # Strip out anything in brackets as that is the fullname
+                    # of the user. It can also have commas in it, so we'll just
+                    # drop it.
+                    $value =~ s/\s+\(.*?\)//g;
 
-                    $changes++;
-                    my ($ok, $msg) = $asset->AddRoleMember( PrincipalId => $user->PrincipalId, Type => $field );
-                    unless ($ok) {
-                        RT->Logger->error("Failed to set $field to $value for row $i: $msg");
+                    # Usernames can have commas in them (huh? yes, try it),
+                    # so we need to split on ", ". Turns out they can also
+                    # have spaces. People that put ", " in a username get
+                    # to keep the pieces.
+                    for my $username (split(/,\s/, $value)) {
+			$username =~ s/\+$//;
+
+		       	# Is it safe to assume the Nobody account always starts with Nobody?
+                        if ($username =~ /^Nobody/) {
+                            $user = RT->Nobody;
+                        } else {
+                            $user->Load( $username );
+                        }
+
+                        if (! $user->id ) {
+                            RT->Logger->error("Unable to find user $username in $field for row $i, skipping");
+                            next;
+                        }
+                        next if $asset->RoleGroup($field)->HasMember( $user->PrincipalId );
+
+                        my ($ok, $msg) = $asset->AddRoleMember( PrincipalId => $user->PrincipalId, Type => $field );
+			if ($ok) {
+                            $changes++;
+		        } else {
+                            RT->Logger->error("Failed to add $username in $field for row $i: $msg");
+                        }
                     }
                 } else {
                     if ($field eq "Catalog") {
@@ -417,6 +440,13 @@ the C<%AssetsImportFieldMapping>:
 
 This requires that, after the import, RT becomes the generator of all
 asset ids.  Otherwise, asset id conflicts may occur.
+
+=head2 Roles
+
+You can add multiple principals to role which support that (HeldBy) by
+separating them with ", ". The space is required as commas are allowed in
+usernames within RT. If you have a username with ", " in it, then sorry, you
+can add to assets with this tool.
 
 =head1 AUTHOR
 

--- a/lib/RT/Extension/Assets/Import/CSV.pm
+++ b/lib/RT/Extension/Assets/Import/CSV.pm
@@ -58,7 +58,7 @@ sub run {
                     "Missing custom field $cfname for "._column($field2csv->{$fieldname}).", skipping");
                 delete $field2csv->{$fieldname};
             }
-        } elsif ($fieldname =~ /^(id|Name|Status|Description|Catalog|Created|LastUpdated)$/) {
+        } elsif ($fieldname =~ /^(id|Name|Status|Description|Catalog|Catalogue|Created|LastUpdated)$/) {
             # no-op, these are fine
         } elsif ( RT::Asset->HasRole($fieldname) ) {
             # no-op, roles are fine
@@ -169,15 +169,17 @@ sub run {
                     # Manage roles linkg to principals.
                     process_roles_field(\%args, $asset, $i, $field, $value, \$changes);
                 } else {
-                    if ($field eq "Catalog") {
+                    my $method = $field;
+                    if ($field =~ "Catalog(ue)?") {
                         my $catalog = RT::Catalog->new( $args{CurrentUser} );
                         $catalog->Load( $value );
                         $value = $catalog->id;
+                        $method = 'Catalog';
                     }
 
-                    if ($asset->$field ne $value) {
+                    if ($asset->$method ne $value) {
                         $changes++;
-                        my $method = "Set" . $field;
+                        $method = "Set" . $method;
                         my ($ok, $msg) = $asset->$method( $value );
                         unless ($ok) {
                             RT->Logger->error("Failed to set $field to $value for row $i: $msg");


### PR DESCRIPTION
This pull request effectively adds support for loading back in the output of Bulk Download of assets. You still need to create a mapping, but this might be enough to allow an attempt at automatic mapping.

Adds support for:
- Add multiple records to Owner (if AssetMultipleOwner enabled), HeldBy, and Contact
- Loading of principal details included in the CSV (remove fullnames, handle Nobody)
- Remove principals from a role if not present in the CSV
- The use of Catalogue as a heading
- Add group(s) to a Role
- Skips any usernames not found - previously they default to Nobody which was mighty annoying.